### PR TITLE
Fix non-reproducible RNG in `simulate_covariates()`

### DIFF
--- a/SynthETIC/R/features_02a_claim_covariates.R
+++ b/SynthETIC/R/features_02a_claim_covariates.R
@@ -403,6 +403,8 @@ simulate_covariates <- function(
         if (exists(".Random.seed", .GlobalEnv, inherits = FALSE)) {
             old_seed <- .GlobalEnv$.Random.seed
             on.exit(.GlobalEnv$.Random.seed <- old_seed)
+        } else {
+            on.exit(rm(".Random.seed", envir = .GlobalEnv))
         }
         set.seed(random_seed)
     }

--- a/SynthETIC/R/features_02a_claim_covariates.R
+++ b/SynthETIC/R/features_02a_claim_covariates.R
@@ -399,7 +399,13 @@ simulate_covariates <- function(
         claim_size_list = list(1),
         random_seed = NULL
 ) {
-    set.seed(random_seed)
+    if (!is.null(random_seed)) {
+        if (exists(".Random.seed", .GlobalEnv, inherits = FALSE)) {
+            old_seed <- .GlobalEnv$.Random.seed
+            on.exit(.GlobalEnv$.Random.seed <- old_seed)
+        }
+        set.seed(random_seed)
+    }
 
     if (!missing(frequency_vector) & !missing(claim_size_list)) {
         stop("specify 'frequency_vector' or 'claim_size_list' but not both")


### PR DESCRIPTION
`simulate_covariates()` unconditionally called `set.seed(random_seed)`.
When `random_seed = NULL` (the default), this called `set.seed(NULL)`
which reinitialises R's RNG from system entropy (time + PID), making
the covariate simulation non-reproducible despite the user having set
a global seed.

When `random_seed` was provided, the call rewound the RNG mid-pipeline,
isolating the covariate draws from the main simulation stream. This
meant earlier draws (claim frequency, occurrence, size) had no effect
on later modules — a silent coupling between modules.

**Fix:**
1. When `random_seed` is provided, save and restore the global
   `.Random.seed` around the isolated `set.seed()` call, so the
   covariate simulation is reproducible without perturbing the parent
   RNG.
2. When `random_seed` is `NULL`, leave the RNG untouched — let the
   caller's `set.seed()` flow through naturally.
3. Handle the edge case where `.Random.seed` doesn't yet exist in
   `.GlobalEnv` (fresh session), to avoid leaking the seed created
   inside the function.
